### PR TITLE
Change of /var/lib/valkey/data is done in Dockerfile

### DIFF
--- a/7/Dockerfile.c10s
+++ b/7/Dockerfile.c10s
@@ -63,7 +63,6 @@ RUN getent group valkey &> /dev/null || groupadd -r valkey &> /dev/null && \
     mkdir -p $VALKEY_LIB/data && chown -R valkey:0 $VALKEY_LIB && \
     mkdir -p $VALKEY_RUN && chown -R valkey:0 $VALKEY_RUN && \
     chmod -R ug+rwX $VALKEY_RUN && \
-    chmod -R ug+rwX $VALKEY_LIB && \
     [[ "$(id valkey)" == "uid=1001(valkey)"* ]]
 
 # Get prefix path and path to scripts rather than hard-code them in scripts


### PR DESCRIPTION
Change of /var/lib/valkey/data is done in /usr/libexec/container-setup.

This change makes problem during the building container 
```
chmod: changing permissions of '/var/lib/valkey/data': Operation not permitted
error building at STEP "RUN getent group valkey &> /dev/null || groupadd -r valkey &> /dev/null &&     usermod -l valkey -aG valkey -c 'Valkey Server' default &> /dev/null &&     INSTALL_PKGS="policycoreutils gettext bind valkey" &&     dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS &&     rpm -V $INSTALL_PKGS &&     dnf -y clean all --enablerepo='*' &&     valkey-server --version | grep -qe "^Server v=$VALKEY_VERSION\." && echo "Found VERSION $VALKEY_VERSION" &&     mkdir -p $VALKEY_LIB/data && chown -R valkey:0 $VALKEY_LIB &&     mkdir -p $VALKEY_RUN && chown -R valkey:0 $VALKEY_RUN &&     chmod -R ug+rwX $VALKEY_RUN &&     chmod -R ug+rwX $VALKEY_LIB &&     [[ "$(id valkey)" == "uid=1001(valkey)"* ]]": error while running runtime: exit status 1
time="2024-08-20T11:06:45Z" level=error msg="exit status 1"
Error: Error: buildah exited with code 1
Trying to pull quay.io/sclorg/s2i-core-c10s:c10s...
Getting image source signatures
```


<!-- issue-commentator = {"comment-id":"2376539772"} -->























<!-- testing-farm = {"lock":"false","comment-id":"2376558301","data":[{"id":"f53fddf3-9649-401f-8dc1-d2ae0fba3e9e","name":"Fedora - 7","status":"complete","outcome":"passed","runTime":393.352978,"created":"2024-09-26T11:01:20.025005","updated":"2024-09-26T11:01:20.025014","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/f53fddf3-9649-401f-8dc1-d2ae0fba3e9e\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/f53fddf3-9649-401f-8dc1-d2ae0fba3e9e/pipeline.log\">pipeline</a>"]},{"id":"79b37a0c-af3f-4072-ae8e-da6accc0667d","name":"CentOS Stream 10 - 7","runTime":511.704372,"created":"2024-09-26T11:01:22.734665","updated":"2024-09-26T11:01:22.734672","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.dev.testing-farm.io/79b37a0c-af3f-4072-ae8e-da6accc0667d\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/79b37a0c-af3f-4072-ae8e-da6accc0667d/pipeline.log\">pipeline</a>"]}]} -->