### PR TITLE
Enable building and testing Valkey version 8 in repository

### DIFF
--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [  "7" ]
+        version: [ "7", "8" ]
         os_test: [ "fedora", "c10s" ]
         test_case: [ "container" ]
 


### PR DESCRIPTION
Running tests is not needed. This only enables support for building and testing Valkey 8


<!-- issue-commentator = {"comment-id":"2572990632"} -->