### PR TITLE
Enable building valkey container on RHEL10.

### DIFF
--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         version: [ "7", "8" ]
-        os_test: [ "fedora", "c10s" ]
+        os_test: [ "fedora", "c10s", "rhel10" ]
         test_case: [ "container" ]
 
     if: |

--- a/.github/workflows/openshift-pytests.yml
+++ b/.github/workflows/openshift-pytests.yml
@@ -27,8 +27,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [ "7" ]
-        os_test: [ "rhel9"]
+        version: [ "7", "8" ]
+        os_test: [ "rhel10" ]
         test_case: [ "openshift-pytest" ]
 
     steps:

--- a/.github/workflows/openshift-tests.yml
+++ b/.github/workflows/openshift-tests.yml
@@ -27,8 +27,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [ "7" ]
-        os_test: [ "rhel9"]
+        version: [ "7", "8" ]
+        os_test: [ "rhel10" ]
         test_case: [ "openshift-4" ]
 
     steps:


### PR DESCRIPTION
Enables building valkey container on RHEL10.

No code is changed.


<!-- issue-commentator = {"comment-id":"2601865955"} -->











<!-- testing-farm = {"lock":"false","comment-id":"2601875772","data":[{"id":"2fb06465-84c6-4680-8108-94e307fb9b3b","name":"CentOS Stream 10 - 7","status":"complete","outcome":"passed","runTime":245.59012,"created":"2025-01-20T09:25:34.833536","updated":"2025-01-20T09:25:34.833544","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/2fb06465-84c6-4680-8108-94e307fb9b3b\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/2fb06465-84c6-4680-8108-94e307fb9b3b/pipeline.log\">pipeline</a>"]},{"id":"e6053de7-4f9a-456b-ad47-98aa6ef6e24f","name":"Fedora - 8","runTime":436.472194,"created":"2025-01-20T09:25:35.519097","updated":"2025-01-20T09:25:35.519150","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.dev.testing-farm.io/e6053de7-4f9a-456b-ad47-98aa6ef6e24f\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/e6053de7-4f9a-456b-ad47-98aa6ef6e24f/pipeline.log\">pipeline</a>"]}]} -->