### PR TITLE
Valkey 8 support for RHEL9

### DIFF
--- a/8/Dockerfile.rhel9
+++ b/8/Dockerfile.rhel9
@@ -1,0 +1,89 @@
+FROM ubi9/s2i-core
+
+# Valkey image based on Software Collections packages
+#
+# Volumes:
+#  * /var/lib/valkey/data - Datastore for Valkey
+# Environment:
+#  * $VALKEY_PASSWORD - Database password
+
+ENV VALKEY_VERSION=8 \
+    HOME=/var/lib/valkey \
+    NAME=valkey
+
+ENV SUMMARY="Valkey in-memory data structure store, used as database, cache and message broker" \
+    DESCRIPTION="Valkey $VALKEY_VERSION available as container, is an advanced key-value store. \
+It is often referred to as a data structure server since keys can contain strings, hashes, lists, \
+sets and sorted sets. You can run atomic operations on these types, like appending to a string; \
+incrementing the value in a hash; pushing to a list; computing set intersection, union and difference; \
+or getting the member with highest ranking in a sorted set. In order to achieve its outstanding \
+performance, Valkey works with an in-memory dataset. Depending on your use case, you can persist \
+it either by dumping the dataset to disk every once in a while, or by appending each command to a log."
+
+LABEL summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="$DESCRIPTION" \
+      io.k8s.display-name="Valkey $VALKEY_VERSION" \
+      io.openshift.expose-services="6379:valkey" \
+      io.openshift.tags="database,valkey,valkey,valkey-$VALKEY_VERSION" \
+      com.redhat.component="valkey-$VALKEY_VERSION-container" \
+      name="rhel9/valkey-$VALKEY_VERSION" \
+      version="$VALKEY_VERSION" \
+      com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#rhel" \
+      usage="podman run -d --name valkey_database -p 6379:6379 rhel9/valkey-$VALKEY_VERSION" \
+      maintainer="SoftwareCollections.org <sclorg@redhat.com>"
+
+EXPOSE 6379
+
+# Get prefix path and path to scripts rather than hard-code them in scripts
+ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/valkey \
+    VALKEY_PREFIX=/usr \
+    VALKEY_CONF=/etc/valkey/valkey.conf \
+    VALKEY_SOCK=/run/valkey/valkey.sock \
+    VALKEY_LIB=/var/lib/valkey \
+    VALKEY_RUN=/run/valkey
+
+
+# Create user for Valkey that has known UID
+# We need to do this before installing the RPMs which would create user with random UID
+# The UID is the one used by the default user from the parent layer (1001),
+# and since the user exists already, do not create a new one, but only rename
+# the existing
+# This image must forever use UID 1001 for Valkey user so our volumes are
+# safe in the future. This should *never* change, the last test is there
+# to make sure of that.
+RUN getent group valkey &> /dev/null || groupadd -r valkey &> /dev/null && \
+    usermod -l valkey -aG valkey -c 'Valkey Server' default &> /dev/null && \
+# Install gettext for envsubst command
+    INSTALL_PKGS="policycoreutils gettext bind9.18-utils valkey" && \
+    dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    dnf -y clean all --enablerepo='*' && \
+    valkey-server --version | grep -qe "^Valkey server v=$VALKEY_VERSION\." && echo "Found VERSION $VALKEY_VERSION" && \
+    mkdir -p $VALKEY_LIB/data && chown -R valkey:0 $VALKEY_LIB && \
+    mkdir -p $VALKEY_RUN && chown -R valkey:0 $VALKEY_RUN && \
+    chmod -R ug+rwX $VALKEY_RUN && \
+    [[ "$(id valkey)" == "uid=1001(valkey)"* ]]
+
+# Get prefix path and path to scripts rather than hard-code them in scripts
+ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/valkey \
+    VALKEY_PREFIX=/usr \
+    VALKEY_CONF=/etc/valkey/valkey.conf
+
+COPY root /
+
+# this is needed due to issues with squash
+# when this directory gets rm'd by the container-setup
+# script.
+RUN /usr/libexec/container-setup
+
+VOLUME ["/var/lib/valkey/data"]
+
+# Using a numeric value because of a comment in [1]:
+# If your S2I image does not include a USER declaration with a numeric user,
+# your builds will fail by default.
+# [1] https://docs.openshift.com/container-platform/4.4/openshift_images/create-images.html#images-create-guide-openshift_create-images
+USER 1001
+
+ENTRYPOINT ["container-entrypoint"]
+CMD ["run-valkey"]

--- a/test/test-lib-valkey.sh
+++ b/test/test-lib-valkey.sh
@@ -14,6 +14,10 @@ source "${THISDIR}/test-lib-remote-openshift.sh"
 
 function test_valkey_integration() {
   local service_name=valkey
+  if [[ "${OS}" == "rhel9" ]]; then
+    echo "RHEL9 imagestream is not supported yet."
+    return
+  fi
   local tag="-el9"
   if [ "${OS}" == "rhel10" ]; then
     tag="-el10"
@@ -32,6 +36,10 @@ function test_valkey_integration() {
 }
 
 function test_valkey_imagestream() {
+  if [[ "${OS}" == "rhel9" ]]; then
+    echo "RHEL9 imagestream is not supported yet."
+    return
+  fi
   local tag="-el9"
   if [ "${OS}" == "rhel10" ]; then
     tag="-el10"

--- a/test/test_valkey_helm_template.py
+++ b/test/test_valkey_helm_template.py
@@ -16,7 +16,7 @@ OS = os.getenv("TARGET")
 
 TAG = TAGS.get(OS)
 
-class TestHelmRedisPersistent:
+class TestHelmValkeyPersistent:
 
     def setup_method(self):
         package_name = "redhat-valkey-persistent"
@@ -31,6 +31,8 @@ class TestHelmRedisPersistent:
         self.hc_api.delete_project()
 
     def test_package_persistent_by_helm_chart_test(self):
+        if OS == "rhel9":
+            pytest.skip("Not supported in RHEL9 yet.")
         self.hc_api.package_name = "redhat-valkey-imagestreams"
         self.hc_api.helm_package()
         assert self.hc_api.helm_installation()

--- a/test/test_valkey_imagestream.py
+++ b/test/test_valkey_imagestream.py
@@ -34,6 +34,8 @@ class TestValkeyImagestreamTemplate:
         ]
     )
     def test_valkey_imagestream_template(self, template):
+        if OS == "rhel9":
+            pytest.skip("Not supported in RHEL9 yet.")
         os_name = ''.join(i for i in OS if not i.isdigit())
         assert self.oc_api.deploy_image_stream_template(
             imagestream_file=f"imagestreams/valkey-{os_name}.json",

--- a/test/test_valkey_imagestream_template.py
+++ b/test/test_valkey_imagestream_template.py
@@ -36,6 +36,8 @@ class TestValkeyImagestreamTemplate:
         ]
     )
     def test_valkey_imagestream_template(self, template):
+        if OS == "rhel9":
+            pytest.skip("Not supported in RHEL9 yet.")
         os_name = ''.join(i for i in OS if not i.isdigit())
         assert self.oc_api.deploy_image_stream_template(
             imagestream_file=f"imagestreams/valkey-{os_name}.json",

--- a/test/test_valkey_template.py
+++ b/test/test_valkey_template.py
@@ -32,6 +32,8 @@ class TestRedisDeployTemplate:
         ]
     )
     def test_valkey_template_inside_cluster(self, template):
+        if OS == "rhel9":
+            pytest.skip("Not supported in RHEL9 yet.")
         assert self.oc_api.deploy_template_with_image(
             image_name=IMAGE_NAME,
             template=f"examples/{template}",


### PR DESCRIPTION
This pull request adds support for Valkey 8 on RHEL9.

<!-- issue-commentator = {"comment-id":"2999934844"} -->

<!-- testing-farm = {"lock":"false","comment-id":"2999966905","data":[{"id":"10220e86-2746-4202-9811-51a0c0aa15c1","name":"CentOS Stream 10 - 8","status":"complete","outcome":"passed","runTime":329.761709,"created":"2025-07-02T09:37:45.566447","updated":"2025-07-02T09:37:45.566453","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/10220e86-2746-4202-9811-51a0c0aa15c1\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/10220e86-2746-4202-9811-51a0c0aa15c1/pipeline.log\">pipeline</a>"]},{"id":"ba9f7a33-e920-4a5e-bf1a-bd54b1642d10","name":"Fedora - 8","status":"complete","outcome":"passed","runTime":368.796159,"created":"2025-07-02T09:37:43.713355","updated":"2025-07-02T09:37:43.713361","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/ba9f7a33-e920-4a5e-bf1a-bd54b1642d10\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/ba9f7a33-e920-4a5e-bf1a-bd54b1642d10/pipeline.log\">pipeline</a>"]},{"id":"80b86a4f-665f-45e7-9d2a-9f71a25a85ca","name":"RHEL10 - 8","runTime":850.900723,"created":"2025-07-02T09:37:42.184106","updated":"2025-07-02T09:37:42.184139","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/80b86a4f-665f-45e7-9d2a-9f71a25a85ca\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/80b86a4f-665f-45e7-9d2a-9f71a25a85ca/pipeline.log\">pipeline</a>"]},{"id":"1177dccf-634d-43db-98ad-2ebfd939bc4e","name":"RHEL9 - 8","status":"complete","outcome":"passed","runTime":955.870959,"created":"2025-07-02T09:37:41.109378","updated":"2025-07-02T09:37:41.109385","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/1177dccf-634d-43db-98ad-2ebfd939bc4e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/1177dccf-634d-43db-98ad-2ebfd939bc4e/pipeline.log\">pipeline</a>"]},{"id":"58eea935-ae76-4ba4-9b1a-0a25060c22ac","name":"RHEL10 - OpenShift 4 - 8","status":"complete","outcome":"passed","runTime":898.864021,"created":"2025-07-01T12:43:36.209678","updated":"2025-07-01T12:43:36.209683","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/58eea935-ae76-4ba4-9b1a-0a25060c22ac\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/58eea935-ae76-4ba4-9b1a-0a25060c22ac/pipeline.log\">pipeline</a>"]},{"id":"fb25c178-8bf3-4325-88fb-18916c3cecc6","name":"RHEL10 - PyTest - OpenShift 4 - 8","status":"complete","outcome":"passed","runTime":1142.601012,"created":"2025-07-01T12:43:38.269735","updated":"2025-07-01T12:43:38.269742","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/fb25c178-8bf3-4325-88fb-18916c3cecc6\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/fb25c178-8bf3-4325-88fb-18916c3cecc6/pipeline.log\">pipeline</a>"]},{"id":"f84dde94-2f1f-4c15-b01b-e1dd05f7e08e","name":"RHEL9 - OpenShift 4 - 8","status":"complete","outcome":"passed","runTime":965.175681,"created":"2025-07-01T12:43:36.539398","updated":"2025-07-01T12:43:36.539404","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/f84dde94-2f1f-4c15-b01b-e1dd05f7e08e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/f84dde94-2f1f-4c15-b01b-e1dd05f7e08e/pipeline.log\">pipeline</a>"]},{"id":"e571491e-1289-4acb-b3fe-4b35dfa2cd11","name":"RHEL9 - PyTest - OpenShift 4 - 8","status":"complete","outcome":"passed","runTime":1159.918711,"created":"2025-07-01T12:43:48.684311","updated":"2025-07-01T12:43:48.684318","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/e571491e-1289-4acb-b3fe-4b35dfa2cd11\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/e571491e-1289-4acb-b3fe-4b35dfa2cd11/pipeline.log\">pipeline</a>"]}]} -->