### PR TITLE
Add distgen check to GitHub workflow

### DIFF
--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -3,10 +3,12 @@ on:
     types:
       - created
 jobs:
+  distgen-check:
+    uses: "sclorg/ci-actions/.github/workflows/distgen-check.yml@main"
   check-readme:
     uses: "sclorg/ci-actions/.github/workflows/check-readme.yml@main"
   container-tests:
-    needs: check-readme
+    needs: [check-readme, distgen-check]
     uses: "sclorg/ci-actions/.github/workflows/container-tests.yml@main"
     with:
       enabled-tests: '["container","container-pytest","openshift-pytest"]'


### PR DESCRIPTION
## Summary
- Adds the `distgen-check` job to the CI workflow, which validates that all distgen-generated files are in sync with their source templates
- This check should be merged **before** the distgen onboarding PR to ensure the CI pipeline validates generated sources going forward

## Test plan
- [ ] Verify the `distgen-check` job appears in CI and passes

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI/CD workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- issue-commentator = {"comment-id":"4660110042"} -->