### PR TITLE
Add RHEL App Streams lifecycle information to README files

### DIFF
--- a/8/root/usr/share/container-scripts/valkey/README.md
+++ b/8/root/usr/share/container-scripts/valkey/README.md
@@ -21,6 +21,7 @@ or getting the member with highest ranking in a sorted set. In order to achieve 
 performance, Valkey works with an in-memory dataset. Depending on your use case, you can persist
 it either by dumping the dataset to disk every once in a while, or by appending each command to a log.
 
+See [the Red Hat Enterprise Linux Application Streams Life Cycle page](https://access.redhat.com/support/policy/updates/rhel-app-streams-life-cycle) for information about support for this particular stream.
 
 Usage
 -----

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Table start
 Table end
 -->
 
+See [the Red Hat Enterprise Linux Application Streams Life Cycle page](https://access.redhat.com/support/policy/updates/rhel-app-streams-life-cycle) for information about support for a particular stream.
+
 Installation
 ------------
 To build a valkey image, choose either the CentOS Stream:

--- a/src/root/usr/share/container-scripts/valkey/README.md
+++ b/src/root/usr/share/container-scripts/valkey/README.md
@@ -21,6 +21,7 @@ or getting the member with highest ranking in a sorted set. In order to achieve 
 performance, Valkey works with an in-memory dataset. Depending on your use case, you can persist
 it either by dumping the dataset to disk every once in a while, or by appending each command to a log.
 
+See [the Red Hat Enterprise Linux Application Streams Life Cycle page](https://access.redhat.com/support/policy/updates/rhel-app-streams-life-cycle) for information about support for this particular stream.
 
 Usage
 -----


### PR DESCRIPTION
Links users to support policy documentation for Valkey stream lifecycle.

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->

<!-- issue-commentator = {"comment-id":"4716335912"} -->

<!-- testing-farm = {"lock":"false","comment-id":"4790069751","data":[{"id":"ed7adc56-03a6-4b45-8399-8df66dac3c74","name":"Fedora - 8","status":"complete","outcome":"passed","runTime":478.2668,"created":"2026-06-24T13:52:06.544061","updated":"2026-06-24T13:52:06.544069","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/ed7adc56-03a6-4b45-8399-8df66dac3c74\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/ed7adc56-03a6-4b45-8399-8df66dac3c74/pipeline.log\">pipeline</a>"]},{"id":"eff759e7-f7ff-44cb-a58c-cb26691b7652","name":"CentOS Stream 10 - 8","status":"complete","outcome":"passed","runTime":541.526663,"created":"2026-06-24T13:52:03.257968","updated":"2026-06-24T13:52:03.257976","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/eff759e7-f7ff-44cb-a58c-cb26691b7652\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/eff759e7-f7ff-44cb-a58c-cb26691b7652/pipeline.log\">pipeline</a>"]},{"id":"61aeab70-664a-45a5-9966-f995f6d4ccb7","name":"CentOS Stream 10 - PyTest - 8","status":"complete","outcome":"passed","runTime":586.899353,"created":"2026-06-24T13:52:12.493500","updated":"2026-06-24T13:52:12.493507","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/61aeab70-664a-45a5-9966-f995f6d4ccb7\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/61aeab70-664a-45a5-9966-f995f6d4ccb7/pipeline.log\">pipeline</a>"]},{"id":"2a604a3c-e60a-4122-8c15-45e424441a68","name":"RHEL10 - Unsubscribed host - 8","status":"complete","outcome":"passed","runTime":1065.37441,"created":"2026-06-24T13:51:58.584367","updated":"2026-06-24T13:51:58.584374","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/2a604a3c-e60a-4122-8c15-45e424441a68\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/2a604a3c-e60a-4122-8c15-45e424441a68/pipeline.log\">pipeline</a>"]},{"id":"cb7c0173-989f-4e50-84ff-88f823cafa68","name":"RHEL10 - PyTest - 8","status":"complete","outcome":"passed","runTime":1063.774264,"created":"2026-06-24T13:52:07.904488","updated":"2026-06-24T13:52:07.904494","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/cb7c0173-989f-4e50-84ff-88f823cafa68\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/cb7c0173-989f-4e50-84ff-88f823cafa68/pipeline.log\">pipeline</a>"]},{"id":"fe6563b5-0257-4dec-87cf-6348a18b0b4e","name":"RHEL10 - 8","status":"complete","outcome":"passed","runTime":1085.128064,"created":"2026-06-24T13:51:45.015400","updated":"2026-06-24T13:51:45.015406","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/fe6563b5-0257-4dec-87cf-6348a18b0b4e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/fe6563b5-0257-4dec-87cf-6348a18b0b4e/pipeline.log\">pipeline</a>"]},{"id":"0a9dc73d-2d72-4ad8-9c90-2f22e11f5610","name":"RHEL9 - Unsubscribed host - 8","status":"complete","outcome":"passed","runTime":1288.730105,"created":"2026-06-24T13:52:02.277747","updated":"2026-06-24T13:52:02.277752","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/0a9dc73d-2d72-4ad8-9c90-2f22e11f5610\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/0a9dc73d-2d72-4ad8-9c90-2f22e11f5610/pipeline.log\">pipeline</a>"]},{"id":"bde0d9d6-1b68-42d1-9a4c-9ed4c9a2f53b","name":"RHEL10 - Unsubscribed host - PyTest - 8","status":"complete","outcome":"passed","runTime":1040.04687,"created":"2026-06-24T13:56:30.332002","updated":"2026-06-24T13:56:30.332009","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/bde0d9d6-1b68-42d1-9a4c-9ed4c9a2f53b\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/bde0d9d6-1b68-42d1-9a4c-9ed4c9a2f53b/pipeline.log\">pipeline</a>"]},{"id":"3454b400-a2d2-4060-bbbc-b0b8af52926f","name":"RHEL9 - 8","status":"complete","outcome":"passed","runTime":1345.971944,"created":"2026-06-24T13:51:52.996544","updated":"2026-06-24T13:51:52.996550","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/3454b400-a2d2-4060-bbbc-b0b8af52926f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/3454b400-a2d2-4060-bbbc-b0b8af52926f/pipeline.log\">pipeline</a>"]},{"id":"ded67793-dcba-4d27-95c9-2c01ee550a9f","name":"RHEL9 - Unsubscribed host - PyTest - 8","status":"complete","outcome":"passed","runTime":1336.829639,"created":"2026-06-24T13:52:05.871752","updated":"2026-06-24T13:52:05.871759","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/ded67793-dcba-4d27-95c9-2c01ee550a9f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/ded67793-dcba-4d27-95c9-2c01ee550a9f/pipeline.log\">pipeline</a>"]},{"id":"5e8f8d48-8313-497f-a2ef-c2cd0f82c332","name":"RHEL9 - PyTest - 8","runTime":1360.124946,"created":"2026-06-24T13:52:07.653536","updated":"2026-06-24T13:52:07.653545","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/5e8f8d48-8313-497f-a2ef-c2cd0f82c332\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/5e8f8d48-8313-497f-a2ef-c2cd0f82c332/pipeline.log\">pipeline</a>"]}]} -->